### PR TITLE
Add command info in embed footer ft. optimization

### DIFF
--- a/commands/util/tags.ts
+++ b/commands/util/tags.ts
@@ -2,6 +2,17 @@ import { Command } from '@types'
 
 import { tags } from './tagsList'
 
+const tagDescription = Object.entries(tags)
+  .map(([key, props]) => {
+    return props['title']
+      ? `\`${key}\` - ${props['title']}`
+      : `\`${key}\``
+  })
+  .join('\n')
+
+const tagList = Object.keys(tags)
+const getRandomTag = () => tagList[Math.floor(Math.random() * tagList.length)]
+
 const tagsCommand: Command = {
   regex: /^(tags)$/,
   usage: 'tags',
@@ -10,13 +21,8 @@ const tagsCommand: Command = {
   async callback ({ message, embed }): Promise<void> {
     await message.channel.send(embed({
       title: 'Tags',
-      description: Object.entries(tags)
-        .map(([key, props]) => {
-          return props['title']
-            ? `\`${key}\` - ${props['title']}`
-            : `\`${key}\``
-        })
-        .join('\n'),
+      description: tagDescription,
+      footer: { text: `Example: .tag ${getRandomTag()}` },
     }))
   },
 }


### PR DESCRIPTION
Add relevant info on how to use `.tag` command inside the embed's footer.
Also extract tag list's description to own variable to stop rebuilding info on each command.