### PR TITLE
Add sort to tags list so it is easier to read

### DIFF
--- a/commands/util/tags.ts
+++ b/commands/util/tags.ts
@@ -8,6 +8,7 @@ const tagDescription = Object.entries(tags)
       ? `\`${key}\` - ${props['title']}`
       : `\`${key}\``
   })
+  .sort()
   .join('\n')
 
 const tagList = Object.keys(tags)


### PR DESCRIPTION
Very minor change really. Just adding a .sort() so the tags list is in alphabetical order. Makes it easier to find what you are looking for in the tag list. 

Example:
![image](https://user-images.githubusercontent.com/55674383/152247036-14a12743-09bb-4234-b088-38872ceb182b.png)
